### PR TITLE
Fix documentation headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 <a href="http://themes.3rdwavemedia.com/website-templates/appkit-landing-free-bootstrap-theme-for-developers-and-startups/" target="_blank"><img src="http://themes.3rdwavemedia.com/wp-content/uploads/2016/01/Free-Bootstrap-Theme-for-Developers-Appkit-landing.png" alt="Free Bootstrap Theme for Developers and Startups" /></a>
 
-##Theme Details & Demo
+## Theme Details & Demo
 
 **Demo:** http://themes.3rdwavemedia.com/demo/appkit-landing/
 
-AppKit Landing is a free Bootstrap theme designed to help developers & startups to promote their products and services. The **source LESS files** are included so itÕs very easy to customise the template to suite your needs.
+AppKit Landing is a free Bootstrap theme designed to help developers & startups to promote their products and services. The **source LESS files** are included so itï¿½s very easy to customise the template to suite your needs.
 
 We will update and improve the template based on user feedback so get in touch or leave a comment if you have any questions or suggestions. If you like the template and find it useful, **we'd appreciate your help in spreading the word on your networks**. You can also [follow us on Twitter](https://twitter.com/3rdwave_themes) to be the first to know when we release new templates and other freebies
 
-##Author & License
+## Author & License
 
 This Bootstrap template is made by UX/UI designer [Xiaoying Riley](https://twitter.com/3rdwave_themes) for developers and is 100% FREE under the [Creative Commons Attribution 3.0 License (CC BY 3.0)](http://creativecommons.org/licenses/by/3.0/)
 
 If you'd like to **use the template without the attribution**, you can check out **other license options** via the [theme website](http://themes.3rdwavemedia.com/website-templates/appkit-landing-free-bootstrap-theme-for-developers-and-startups/)
 
-####Follow Xiaoying
+#### Follow Xiaoying
 
 [Twitter](https://twitter.com/3rdwave_themes)
 
@@ -25,13 +25,13 @@ If you'd like to **use the template without the attribution**, you can check out
 [Linkedin](https://uk.linkedin.com/in/xiaoying)
 
 
-##Latest Version
+## Latest Version
 **v1.2** - 28 Dec 2016
 
 [Changelog](http://themes.3rdwavemedia.com/website-templates/appkit-landing-free-bootstrap-theme-for-developers-and-startups/?target=changelog)
 
 
-##Features
+## Features
 
 -  Fully Responsive
 -  HTML5 + CSS3
@@ -41,7 +41,7 @@ If you'd like to **use the template without the attribution**, you can check out
 -  **LESS** files included
 -  Compatible with all modern browsers
 
-##Credits
+## Credits
 - [Bootstrap](http://getbootstrap.com/)
 - [FontAwesome](http://fortawesome.github.io/Font-Awesome/)
 - [Google Fonts](https://fonts.google.com/)


### PR DESCRIPTION
Some of the markdown headers aren't rendering properly on Github because they don't have spaces between the hashes and the title text. This pull request will fix that issue.